### PR TITLE
Make hidden files also copied

### DIFF
--- a/createDevJob.groovy
+++ b/createDevJob.groovy
@@ -7,7 +7,7 @@ if [ -e /var/jenkins_home/jobs/devPipeline/workspace/* ]; then
     rm -r /var/jenkins_home/jobs/devPipeline/workspace/*
 fi
 if [[ ! -z "$(ls -A)" ]] ; then
-    cp -r * /var/jenkins_home/jobs/devPipeline/workspace/
+    cp -r . /var/jenkins_home/jobs/devPipeline/workspace/
 fi
 '''
 

--- a/jenkins/jobs/pipeline-updater/config.xml
+++ b/jenkins/jobs/pipeline-updater/config.xml
@@ -25,7 +25,7 @@ if [ -e /var/jenkins_home/jobs/devPipeline/workspace/* ]; then
     rm -r /var/jenkins_home/jobs/devPipeline/workspace/*
 fi
 if [[ ! -z "$(ls -A)" ]] ; then
-    cp -r * /var/jenkins_home/jobs/devPipeline/workspace/
+    cp -r . /var/jenkins_home/jobs/devPipeline/workspace/
 fi</command>
     </hudson.tasks.Shell>
     <javaposse.jobdsl.plugin.ExecuteDslScripts plugin="job-dsl@1.64">


### PR DESCRIPTION
Fixes #8 

Hidden files should be included in the files copied so that Jenkins pipelines that rely on data in your .git file (such as multistage pipelines using `when { branch "<BRANCH_NAME>" }`).